### PR TITLE
updated to support llvm_asm! over asm!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[path = "platform/linux-x86_64.rs"]

--- a/src/platform/linux-x86_64.rs
+++ b/src/platform/linux-x86_64.rs
@@ -1,6 +1,6 @@
 #[inline(always)]
 pub unsafe fn sys_call0(mut num: isize) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          :
          : "rcx", "r11", "memory"
@@ -10,7 +10,7 @@ pub unsafe fn sys_call0(mut num: isize) -> isize {
 
 #[inline(always)]
 pub unsafe fn sys_call1(mut num: isize, arg1: isize) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          : "{rdi}"(arg1)
          : "rcx", "r11", "memory"
@@ -20,7 +20,7 @@ pub unsafe fn sys_call1(mut num: isize, arg1: isize) -> isize {
 
 #[inline(always)]
 pub unsafe fn sys_call2(mut num: isize, arg1: isize, arg2: isize) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          : "{rdi}"(arg1) "{rsi}"(arg2)
          : "rcx", "r11", "memory"
@@ -30,7 +30,7 @@ pub unsafe fn sys_call2(mut num: isize, arg1: isize, arg2: isize) -> isize {
 
 #[inline(always)]
 pub unsafe fn sys_call3(mut num: isize, arg1: isize, arg2: isize, arg3: isize) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          : "{rdi}"(arg1) "{rsi}"(arg2) "{rdx}"(arg3)
          : "rcx", "r11", "memory"
@@ -46,7 +46,7 @@ pub unsafe fn sys_call4(
     arg3: isize,
     arg4: isize,
 ) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          : "{rdi}"(arg1) "{rsi}"(arg2) "{rdx}"(arg3) "{r10}"(arg4)
          : "rcx", "r11", "memory"
@@ -63,7 +63,7 @@ pub unsafe fn sys_call5(
     arg4: isize,
     arg5: isize,
 ) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          : "{rdi}"(arg1) "{rsi}"(arg2) "{rdx}"(arg3) "{r10}"(arg4) "{r8}"(arg5)
          : "rcx", "r11", "memory"
@@ -81,7 +81,7 @@ pub unsafe fn sys_call6(
     arg5: isize,
     arg6: isize,
 ) -> isize {
-    asm!("syscall"
+    llvm_asm!("syscall"
          : "+{rax}"(num)
          : "{rdi}"(arg1) "{rsi}"(arg2) "{rdx}"(arg3) "{r10}"(arg4) "{r8}"(arg5) "{r9}"(arg6)
          : "rcx", "r11", "memory"


### PR DESCRIPTION
asm! appears to now be llvm_asm!

https://doc.rust-lang.org/beta/unstable-book/library-features/llvm-asm.html

https://github.com/rust-lang/rust/issues/70173

